### PR TITLE
Adding support for test validation via reg exps

### DIFF
--- a/coremark_pro/base_test_results/test1/verify
+++ b/coremark_pro/base_test_results/test1/verify
@@ -1,14 +1,14 @@
 # regexp explanation
 #
 #  Test:Multi\siterations:Single\sIterations:Scaling
-#  :[1-9][0-9.]{0,}:[1-9][0-9.]{0,}:[1-9][0-9.]{0,}$
+#  :[1-9][0-9.]{0,}:[1-9][0-9\.]{0,}:[1-9][0-9\.]{0,}$
 #
 #   Field 1 Test: Any match
 #   Field 2 Multi iterations [1-9][0-9.]{0,}: The number of iterations performed
 #           when multiple threads are running. Value is Positive non-zero decimal decimal value.
-#   Field 3 Single Iterations [1-9][0-9.]{0,}: The number of iterations performed
+#   Field 3 Single Iterations [1-9][0-9\.]{0,}: The number of iterations performed
 #           when multiple threads are running. Value is Positive non-zero decimal decimal value.
-#   Field 4 Scaling [1-9][0-9.]{0,}$: The number of iterations performed
+#   Field 4 Scaling [1-9][0-9\.]{0,}$: The number of iterations performed
 #           when multiple threads are running. Value is Positive non-zero decimal decimal value.
 #
 %_header
@@ -17,4 +17,4 @@ Test:Multi\siterations:Single\sIterations:Scaling
 # We expect multiple lines of results.
 #
 %_multiples
-:[1-9][0-9.]{0,}:[1-9][0-9.]{0,}:[1-9][0-9.]{0,}$
+:[1-9][0-9\.]{0,}:[1-9][0-9\.]{0,}:[1-9][0-9\.]{0,}$

--- a/coremark_pro/base_test_results/test1/verify
+++ b/coremark_pro/base_test_results/test1/verify
@@ -1,3 +1,26 @@
+#
+# Main reg exp summary
+#
+#   Field 1: Any match
+#   Field 2: a non-zero field
+#   Field 3: a non-zero field
+#   Field 4: a non-zero decimal field
+#
+# Detailed Description
+#
+# :[1-9][0-9.]{0,}:[1-9][0-9.]{0,}:[1-9][0-9.]{0,}$
+#
+#   [1-9][0-9.]{0,}
+#      [1-9]: Matches a single digit from 1 to 9 (i.e., a non-zero digit).
+#      [0-9.]{0,}: Matches zero or more occurrences of either a digit (0-9) or a literal dot (.).
+#   [1-9][0-9.]{0,}
+#      [1-9]: Matches a single digit from 1 to 9 (i.e., a non-zero digit).
+#      [0-9.]{0,}: Matches zero or more occurrences of either a digit (0-9) or a literal dot (.).
+#   [1-9][0-9.]{0,}$
+#      [1-9]: Matches a single digit from 1 to 9 (i.e., a non-zero digit).
+#      [0-9.]{0,}: Matches zero or more occurrences of either a digit (0-9) or a literal dot (.).
+#       $: This is an anchor that matches the end of the line. It ensures that the entire matched pattern must occur at the very end of the line.
+#
 %_header
 Test:Multi\siterations:Single\sIterations:Scaling
 %_multiples

--- a/coremark_pro/base_test_results/test1/verify
+++ b/coremark_pro/base_test_results/test1/verify
@@ -1,27 +1,20 @@
+# regexp explanation
 #
-# Main reg exp summary
+#  Test:Multi\siterations:Single\sIterations:Scaling
+#  :[1-9][0-9.]{0,}:[1-9][0-9.]{0,}:[1-9][0-9.]{0,}$
 #
-#   Field 1: Any match
-#   Field 2: a non-zero field
-#   Field 3: a non-zero field
-#   Field 4: a non-zero decimal field
-#
-# Detailed Description
-#
-# :[1-9][0-9.]{0,}:[1-9][0-9.]{0,}:[1-9][0-9.]{0,}$
-#
-#   [1-9][0-9.]{0,}
-#      [1-9]: Matches a single digit from 1 to 9 (i.e., a non-zero digit).
-#      [0-9.]{0,}: Matches zero or more occurrences of either a digit (0-9) or a literal dot (.).
-#   [1-9][0-9.]{0,}
-#      [1-9]: Matches a single digit from 1 to 9 (i.e., a non-zero digit).
-#      [0-9.]{0,}: Matches zero or more occurrences of either a digit (0-9) or a literal dot (.).
-#   [1-9][0-9.]{0,}$
-#      [1-9]: Matches a single digit from 1 to 9 (i.e., a non-zero digit).
-#      [0-9.]{0,}: Matches zero or more occurrences of either a digit (0-9) or a literal dot (.).
-#       $: This is an anchor that matches the end of the line. It ensures that the entire matched pattern must occur at the very end of the line.
+#   Field 1 Test: Any match
+#   Field 2 Multi iterations [1-9][0-9.]{0,}: The number of iterations performed
+#           when multiple threads are running. Value is Positive non-zero decimal decimal value.
+#   Field 3 Single Iterations [1-9][0-9.]{0,}: The number of iterations performed
+#           when multiple threads are running. Value is Positive non-zero decimal decimal value.
+#   Field 4 Scaling [1-9][0-9.]{0,}$: The number of iterations performed
+#           when multiple threads are running. Value is Positive non-zero decimal decimal value.
 #
 %_header
 Test:Multi\siterations:Single\sIterations:Scaling
+#
+# We expect multiple lines of results.
+#
 %_multiples
 :[1-9][0-9.]{0,}:[1-9][0-9.]{0,}:[1-9][0-9.]{0,}$

--- a/coremark_pro/base_test_results/test1/verify
+++ b/coremark_pro/base_test_results/test1/verify
@@ -1,4 +1,4 @@
 %_header
 Test:Multi\siterations:Single\sIterations:Scaling
 %_multiples
-:[0-9.]{1,}:[0-9.]{1,}:[0-9.]{1,}$
+:[1-9][0-9.]{0,}:[1-9][0-9.]{0,}:[1-9][0-9.]{0,}$

--- a/coremark_pro/base_test_results/test1/verify
+++ b/coremark_pro/base_test_results/test1/verify
@@ -1,0 +1,4 @@
+%_header
+Test:Multi\siterations:Single\sIterations:Scaling
+%_multiples
+:[0-9.]{1,}:[0-9.]{1,}:[0-9.]{1,}$

--- a/coremark_pro/base_test_results/test1/verify
+++ b/coremark_pro/base_test_results/test1/verify
@@ -4,12 +4,15 @@
 #  :[1-9][0-9.]{0,}:[1-9][0-9\.]{0,}:[1-9][0-9\.]{0,}$
 #
 #   Field 1 Test: Any match
-#   Field 2 Multi iterations [1-9][0-9.]{0,}: The number of iterations performed
-#           when multiple threads are running. Value is Positive non-zero decimal decimal value.
-#   Field 3 Single Iterations [1-9][0-9\.]{0,}: The number of iterations performed
-#           when multiple threads are running. Value is Positive non-zero decimal decimal value.
-#   Field 4 Scaling [1-9][0-9\.]{0,}$: The number of iterations performed
-#           when multiple threads are running. Value is Positive non-zero decimal decimal value.
+#   Field 2 Multi iterations ([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*):
+#           The number of iterations performed when multiple threads are running.
+#           Value is Positive non-zero decimal value.
+#   Field 3 Single Iterations ([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*):
+#           The number of iterations performed  when multiple threads are running.
+#           Value is Positive non-zero decimal value.
+#   Field 4 Scaling ([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*)$: The number of
+#           iterations performed when multiple threads are running. Value is
+#           Positive non-zero decimal value.
 #
 %_header
 Test:Multi\siterations:Single\sIterations:Scaling
@@ -17,4 +20,4 @@ Test:Multi\siterations:Single\sIterations:Scaling
 # We expect multiple lines of results.
 #
 %_multiples
-:[1-9][0-9\.]{0,}:[1-9][0-9\.]{0,}:[1-9][0-9\.]{0,}$
+:([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*):([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*):([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*)$

--- a/coremark_pro/coremark_pro_run
+++ b/coremark_pro/coremark_pro_run
@@ -26,6 +26,7 @@ commit="none"
 test_name="coremark_pro"
 arguments="$@"
 results_file=results_"${test_name}".csv
+rtc=0
 
 exit_out()
 {
@@ -174,11 +175,7 @@ generate_csv_file()
 save_results()
 {
 	$TOOLS_BIN/validate_line --results_file $results_file --base_results_file $run_dir/base_test_results/test1/verify
-	if [[ $? -eq 0 ]]; then
-		echo Ran >> test_results_report
-	else
-		echo Failed >> test_results_report
-	fi
+	rtc=$?
 	${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --other_files "$summary_file,coremark_pro_run*,test_results_report" --results $results_file --test_name $test_name --tuned_setting $to_tuned_setting --version $coremark_pro_version --user $to_user
 }
 
@@ -430,4 +427,4 @@ if [[ -d "coremark-pro" ]]; then
 fi
 run_coremark_pro
 
-exit 0
+exit $rtc

--- a/coremark_pro/coremark_pro_run
+++ b/coremark_pro/coremark_pro_run
@@ -23,8 +23,9 @@
 #
 coremark_pro_version="v1.1.2743"
 commit="none"
-test_name_run="coremark_pro"
+test_name="coremark_pro"
 arguments="$@"
+results_file=results_"${test_name}".csv
 
 exit_out()
 {
@@ -127,8 +128,8 @@ produce_summary_report()
 			if [[ ${line} == "CoreMark"* ]]; then
 				found=0
 			fi
-			test_name=`echo $line | awk '{print $1}'`
-			pull_data $test_name
+			ind_test_name=`echo $line | awk '{print $1}'`
+			pull_data $ind_test_name
 			continue
 		fi
 		if [[ $line == "------"* ]]; then
@@ -144,8 +145,8 @@ generate_csv_file()
 	# Create the csv file.
 	#
 
-	$TOOLS_BIN/test_header_info --front_matter --results_file results.csv --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $coremark_pro_version --test_name $test_name
-	echo Test:Multi iterations:Single Iterations:Scaling >> results.csv
+	$TOOLS_BIN/test_header_info --front_matter --results_file $results_file --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $coremark_pro_version --test_name $test_name
+	echo Test:Multi iterations:Single Iterations:Scaling >> $results_file
 	items="^cjpeg-rose7-preset ^core ^linear_alg-mid-100x100-sp ^loops-all-mid-10k-sp ^nnet_test ^parser-125k ^radix2-big-64k ^sha-test ^zip-test"
 	for i in $items; do
 		multi_iter=0.0
@@ -166,22 +167,19 @@ generate_csv_file()
 		single_iter=`echo "scale = 2;$single_iter / ${samples}.00" | bc -l`
 		scaling=`echo "scale = 2;$scaling / ${samples}.00" | bc -l` 
 		name=`echo $i | sed "s/\^//g"`
-		echo $name:$multi_iter:$single_iter:$scaling >> results.csv
+		echo $name:$multi_iter:$single_iter:$scaling >> $results_file
 	done
 }
 
 save_results()
 {
-	value=`grep CoreMark-PRO  coremark_pro.summary | head -1`
-	value_out=`echo $value | cut -d' ' -f2,3 | sed "s/ /:/g"`
-	echo "Score:${value_out}"  >>  results.csv
-	grep -q ":::" results.csv
-	if [ $? -eq 0 ]; then
-		echo Failed > test_results_report
+	$TOOLS_BIN/validate_line --results_file $results_file --base_results_file $run_dir/base_test_results/test1/verify
+	if [[ $? -eq 0 ]]; then
+		echo Ran >> test_results_report
 	else
-		echo Ran > test_results_report
+		echo Failed >> test_results_report
 	fi
-	${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --other_files "$summary_file,coremark_pro_run*,test_results_report" --results results.csv --test_name coremark_pro --tuned_setting $to_tuned_setting --version $coremark_pro_version --user $to_user
+	${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --other_files "$summary_file,coremark_pro_run*,test_results_report" --results $results_file --test_name $test_name --tuned_setting $to_tuned_setting --version $coremark_pro_version --user $to_user
 }
 
 #
@@ -295,8 +293,8 @@ run_coremark_pro()
 		source ~/.bashrc
 		cd $curdir
 		arguments="${arguments} --test_iterations ${to_times_to_run}"
-		echo $TOOLS_BIN/execute_via_pbench --cmd_executing "$0" $arguments --test ${test_name_run} --spacing 11 --pbench_stats $to_pstats
-		$TOOLS_BIN/execute_via_pbench --cmd_executing "$0" $arguments --test ${test_name_run} --spacing 11 --pbench_stats $to_pstats
+		echo $TOOLS_BIN/execute_via_pbench --cmd_executing "$0" $arguments --test ${test_name} --spacing 11 --pbench_stats $to_pstats
+		$TOOLS_BIN/execute_via_pbench --cmd_executing "$0" $arguments --test ${test_name} --spacing 11 --pbench_stats $to_pstats
 		if [ $? -ne 0 ]; then
 			exit_out "Execution via pbench failed\n" 1
 		fi
@@ -375,7 +373,9 @@ install_tools_git "$@"
 # to_tuned_setting: tuned setting
 #
 
+pushd ${curdir} 2> /dev/null
 source ${curdir}/test_tools/general_setup "$@"
+popd 2> /dev/null
 
 ARGUMENT_LIST=(
 	"commit"

--- a/coremark_pro/verification_config/test_verify
+++ b/coremark_pro/verification_config/test_verify
@@ -1,0 +1,3 @@
+Required_Systems: intel,amd,arm
+Via_Zathras: No
+test:--iterations 1  --no-overrides:base_test_results/test1/verify


### PR DESCRIPTION
# Description
This adds the required files and hooks into the wrapper for verification of the test results via regexp.

Mapping results to regexp
Typical results
Test:Multi iterations:Single Iterations:Scaling
cjpeg-rose7-preset:526.32:204.08:2.58
core:5.78:2.42:2.39
linear_alg-mid-100x100-sp:714.29:320.51:2.23
loops-all-mid-10k-sp:23.75:9.08:2.62
nnet_test:25.19:11.01:2.29
parser-125k:125.00:50.00:2.50
radix2-big-64k:1763.67:501.50:3.52
sha-test:588.24:294.12:2.00
zip-test:400.00:142.86:2.80
Score:18369.23:7300.06

Regexp file contents
%_header
Test:Multi\siterations:Single\sIterations:Scaling
%_multiples
:[1-9][0-9.]{0,}:[1-9][0-9.]{0,}:[1-9][0-9.]{0,}$

%_header: Indicates the next line is a header that we need to match. The \s indicates we expect a space,
%_multiples: The following will match any number of lines  (>1).  
  Field 1: Will match any string
  Field 2,3 and 4 Must be a non zero value

# Before/After Comparison

Before change: Failures will occur on validation
After change: Passes when it should, fails when it should.

# Clerical Stuff
This closes #39 

Relates to JIRA: RPOPC-347

# Testing
Running the wrapper (modifying the regexps to force failures)
Verified test fails when it has bad data
Verified test passes when we have good data.


