### PR TITLE
Update error codes to be more specific

### DIFF
--- a/coremark_pro/coremark_pro_run
+++ b/coremark_pro/coremark_pro_run
@@ -114,7 +114,7 @@ attempt_tools_wget()
         fi
 }
 
-attetmpt_tools_curl()
+attempt_tools_curl()
 {
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 curl -L -O ${tools_git}/archive/refs/heads/main.zip
@@ -137,7 +137,7 @@ attempt_tools_git()
 }
 
 attempt_tools_wget
-attetmpt_tools_curl
+attempt_tools_curl
 attempt_tools_git
 
 #

--- a/coremark_pro/coremark_pro_run
+++ b/coremark_pro/coremark_pro_run
@@ -335,17 +335,17 @@ run_coremark_pro()
 		if [[ $commit == "none" ]]; then
 			GIT_TERMINAL_PROMPT=0 git -c advice.detachedHead=false clone --depth 1 --branch ${coremark_pro_version} https://github.com/eembc/coremark-pro
 			if [ $? -ne 0 ]; then
-				exit_out "Failed to clone https://github.com/eembc/coremark-pro version ${coremark_pro_version}" 1
+				exit_out "Failed to clone https://github.com/eembc/coremark-pro version ${coremark_pro_version}" $E_GENERAL
 			fi
 		else
 			GIT_TERMINAL_PROMPT=0 git -c advice.detachedHead=false clone https://github.com/eembc/coremark-pro
 			if [ $? != 0 ]; then
-				exit_out "Failed to clone https://github.com/eembc/coremark-pro" 1
+				exit_out "Failed to clone https://github.com/eembc/coremark-pro" $E_GENERAL
 			fi
 			pushd coremark-pro > /dev/null
 			GIT_TERMINAL_PROMPT=0 git checkout ${commit}
 			if [ $? -ne 0 ]; then
-				exit_out "Failed to checkout ${commit}" 1
+				exit_out "Failed to checkout ${commit}" $E_GENERAL
 			fi
 			popd > /dev/null
 		fi
@@ -384,7 +384,7 @@ run_coremark_pro()
 		# Make failed, rerun and do not keep quiet about it.
 		#
 		make TARGET=linux64 build
-		exit_out "make of test failed, exiting" 1
+		exit_out "make of test failed, exiting" $E_GENERAL
 	fi
 	numb_cpus=`cat /proc/cpuinfo | grep processor | wc -l`
 	for iter in $(seq 1 1 $to_times_to_run); do
@@ -399,7 +399,7 @@ run_coremark_pro()
 		padded_iter=$(format_iteration_number $iter $to_times_to_run)
 		make -s $make_flags > coremark_pro_run_${padded_iter}
 		if [ $? -ne 0 ]; then
-			exit_out "Run failed, make $make_flags" 1
+			exit_out "Run failed, make $make_flags" $E_GENERAL
 		fi
 		end_time=$(retrieve_time_stamp)
 		#
@@ -474,7 +474,7 @@ usage()
 	echo "  --no-overrides: If present we will not tune the make files"
 	echo "  --test_iterations n: number of times to run the test."
 	source ${TOOLS_BIN}/general_setup --usage
-	exit 0
+	exit $E_USAGE
 }
 
 #
@@ -500,7 +500,7 @@ source ${TOOLS_BIN}/general_setup "$@"
 # Install needed packages based on the wrapper's JSON file
 package_tool --no_packages $to_no_pkg_install --wrapper_config ${run_dir}/coremark_pro-packages.json
 if [[ $? -ne 0 ]]; then
-	exit_out "package_tool reported failure installing dependencies." 1
+	exit_out "package_tool reported failure installing dependencies." $E_GENERAL
 fi
 
 ARGUMENT_LIST=(
@@ -546,7 +546,7 @@ while [[ $# -gt 0 ]]; do
 			break
 		;;
 		*)
-			exit_out "option not found $1" 1
+			exit_out "option not found $1" $E_GENERAL
 		;;
 	esac
 done

--- a/coremark_pro/coremark_pro_run
+++ b/coremark_pro/coremark_pro_run
@@ -58,12 +58,12 @@ format_iteration_number()
 	printf "%0${digits}d" $iter
 }
 
-if [ ! -f "/tmp/${test_name_run}.out" ]; then
+if [ ! -f "/tmp/${test_name}.out" ]; then
 	command="${0} $@"
-	$command &> /tmp/${test_name_run}.out
+	$command &> /tmp/${test_name}.out
 	rtc=$?
-	cat /tmp/${test_name_run}.out
-	rm /tmp/${test_name_run}.out
+	cat /tmp/${test_name}.out
+	rm /tmp/${test_name}.out
 	exit $rtc
 fi
 

--- a/coremark_pro/coremark_pro_run
+++ b/coremark_pro/coremark_pro_run
@@ -101,12 +101,44 @@ rm -f $summary_file
 tools_git=https://github.com/redhat-performance/test_tools-wrappers
 TOOLS_BIN=${HOME}/test_tools
 export TOOLS_BIN
-if [ ! -d "${TOOLS_BIN}" ]; then
-	git clone $tools_git ${TOOLS_BIN}
-	if [ $? -ne 0 ]; then
-		exit_out "pulling git $tools_git failed." 1
-	fi
-fi
+
+attempt_tools_wget()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                wget ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attetmpt_tools_curl()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_git()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                git clone $tools_git "$TOOLS_BIN"
+                if [ $? -ne 0 ]; then
+                        exit_out "Error: pulling git $tools_git failed." 1
+                fi
+        fi
+}
+
+attempt_tools_wget
+attetmpt_tools_curl
+attempt_tools_git
 
 #
 # Gather hardware information

--- a/coremark_pro/coremark_pro_run
+++ b/coremark_pro/coremark_pro_run
@@ -131,7 +131,7 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                        exit_out "Error: pulling git $tools_git failed." 1
+                        exit_out "Error: pulling git $tools_git failed." 101
                 fi
         fi
 }


### PR DESCRIPTION
# Description
Uses error_codes found in test_tools/error_codes to provide more specific error indication.

# Before/After Comparison
Before: Returned a 0 or 1, making determination of having to rerun very course
After: Error codes are now bases on test_tools/error_codes, making it easier to limit when we do a rerun of the test.
Also, changed how we load in test_tools, we try curl, git, and wget, to avoid a failure due to the program not
being installed.

# Clerical Stuff
This closes #57


Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-871

Testing Done
Ran scenario file
global:
  ssh_key_file: replace_your_ssh_key
  terminate_cloud: 1
  os_vendor: rhel
  results_prefix: documentation
  os_vendor: rhel
  system_type: aws
  cloud_os_id: ami-035032ea878eca201
systems:
  system1:
    tests: "coremark_pro"
    host_config: "m5.xlarge"


csv results file
Test,Multi_iterations,Single_iterations,Scaling,Start_Date,End_Date
cjpeg-rose7-preset,384.62,147.06,2.62,2026-03-13T14:47:59Z,2026-03-13T14:48:59Z
core,4.20,1.70,2.47,2026-03-13T14:47:59Z,2026-03-13T14:48:59Z
linear_alg-mid-100x100-sp,314.47,146.20,2.15,2026-03-13T14:47:59Z,2026-03-13T14:48:59Z
loops-all-mid-10k-sp,16.68,6.48,2.57,2026-03-13T14:47:59Z,2026-03-13T14:48:59Z
nnet_test,19.31,8.51,2.27,2026-03-13T14:47:59Z,2026-03-13T14:48:59Z
parser-125k,121.21,34.48,3.52,2026-03-13T14:47:59Z,2026-03-13T14:48:59Z
radix2-big-64k,1602.56,601.68,2.66,2026-03-13T14:47:59Z,2026-03-13T14:48:59Z
sha-test,384.62,192.31,2.00,2026-03-13T14:47:59Z,2026-03-13T14:48:59Z
zip-test,285.71,125.00,2.29,2026-03-13T14:47:59Z,2026-03-13T14:48:59Z
Score,13219.99,5343.15,2.47,2026-03-13T14:47:59Z,2026-03-13T14:48:59Z

Returned 0 as expected. Testing on rerun verification handled in the appropriate zathras pr.